### PR TITLE
Updates for the scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,14 @@ $ ./build_operator_image.sh --username johndow --operator machine-config-operato
 ```txt
 Usage: ./build_release_image.sh [options] -u <quay.io username>
 Options:
--h, --help     show this message
--u, --username registered username in quay.io
--t, --tag      push to a custom tag in your origin release image repo, default: latest
--r, --release  openshift release version, default: 4.11
--a, --auth     path of registry auth file, default: ./pull-secrets/pull-secret.txt
--i, --image    image(s) to replace in the release payload in the format '<component_name>=<image_path>'
---dry-run      if set, build but do not push the image to image registry, default: false
+-h, --help       show this message
+-u, --username   registered username in quay.io
+-t, --tag        push to a custom tag in your origin release image repo, default: latest
+-r, --release    openshift release version, default: 4.11
+-a, --auth       path of registry auth file, default: ./pull-secrets/pull-secret.txt
+-i, --image      image(s) to replace in the release payload in the format '<component_name>=<image_path>'
+--release-image  custom base release image to build from, default: the latest image for the given release version
+--dry-run        if set, build but do not push the image to image registry, default: false
 ```
 
 To build an actual release image with your custom Machine Config Operator image, that was created in the previous step, execute

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Options:
 -u, --username    registered username in quay.io
 -t, --tag         push to a custom tag in your origin release image repo, default: latest
 -d, --dockerfile  non-default Dockerfile name, default: Dockerfile
+--dry-run         if set, build but do not push the image to image registry, default: false
 ```
 
 For instance, if you want to build a Machine Config Operator image with your custom change specified by PR [\#2606](https://github.com/openshift/machine-config-operator/pull/2606) and then push it into your personal quay.io, execute
@@ -63,6 +64,7 @@ Options:
 -r, --release  openshift release version, default: 4.11
 -a, --auth     path of registry auth file, default: ./pull-secrets/pull-secret.txt
 -i, --image    image(s) to replace in the release payload in the format '<component_name>=<image_path>'
+--dry-run      if set, build but do not push the image to image registry, default: false
 ```
 
 To build an actual release image with your custom Machine Config Operator image, that was created in the previous step, execute

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Options:
 -h, --help     show this message
 -u, --username registered username in quay.io
 -t, --tag      push to a custom tag in your origin release image repo, default: latest
--r, --release  openshift release version, default: 4.10
+-r, --release  openshift release version, default: 4.11
 -a, --auth     path of registry auth file, default: ./pull-secrets/pull-secret.txt
 -i, --image    image(s) to replace in the release payload in the format '<component_name>=<image_path>'
 ```

--- a/README.md
+++ b/README.md
@@ -61,14 +61,14 @@ Options:
 -u, --username registered username in quay.io
 -t, --tag      push to a custom tag in your origin release image repo, default: latest
 -r, --release  openshift release version, default: 4.10
--a, --auth     path of registry auth file, default: ./pull-secret.txt
+-a, --auth     path of registry auth file, default: ./pull-secrets/pull-secret.txt
 -i, --image    image(s) to replace in the release payload in the format '<component_name>=<image_path>'
 ```
 
 To build an actual release image with your custom Machine Config Operator image, that was created in the previous step, execute
 
 ```sh
-$ ./build_release_image.sh --username johndow --auth ~/pull-secret.txt -i machine-config-operator=quay.io/johndow/machine-config-operator:latest
+$ ./build_release_image.sh --username johndow --auth ~/pull-secrets/pull-secret.txt -i machine-config-operator=quay.io/johndow/machine-config-operator:latest
 ```
 
 To replace other component images add more `-i` options (`-i cluster-kube-controller-manager-operator=quay.io/johndow/cluster-kube-controller-manager-operator:latest` for Kube Controller Manager Operator, `-i aws-cloud-controller-manager=quay.io/johndow/aws-cloud-controller-manager:latest` for AWS Cloud Controller manager, and so on). It is possible to replace several images at once.

--- a/build_all.example.sh
+++ b/build_all.example.sh
@@ -10,12 +10,12 @@ help() {
     echo "-h, --help      show this message"
     echo "-u, --username  registered username in quay.io"
     echo "-t, --tag       push to a custom tag in your origin release image repo, default: latest"
-    echo "-r, --release   openshift release version, default: 4.10"
+    echo "-r, --release   openshift release version, default: 4.11"
     echo "-a, --auth      path of registry auth file, default: ./pull-secrets/pull-secret.txt"
 }
 
 : ${TAG:="latest"}
-: ${RELEASE:="4.10"}
+: ${RELEASE:="4.11"}
 : ${OC_REGISTRY_AUTH_FILE:=$(pwd)"/pull-secrets/pull-secret.txt"}
 
 while [[ $# -gt 0 ]]; do

--- a/build_all.example.sh
+++ b/build_all.example.sh
@@ -11,12 +11,12 @@ help() {
     echo "-u, --username  registered username in quay.io"
     echo "-t, --tag       push to a custom tag in your origin release image repo, default: latest"
     echo "-r, --release   openshift release version, default: 4.10"
-    echo "-a, --auth      path of registry auth file, default: ./pull-secret.txt"
+    echo "-a, --auth      path of registry auth file, default: ./pull-secrets/pull-secret.txt"
 }
 
 : ${TAG:="latest"}
 : ${RELEASE:="4.10"}
-: ${OC_REGISTRY_AUTH_FILE:=$(pwd)"/pull-secrets/pull-secrets.json"}
+: ${OC_REGISTRY_AUTH_FILE:=$(pwd)"/pull-secrets/pull-secret.txt"}
 
 while [[ $# -gt 0 ]]; do
     case "$1" in

--- a/build_capi_release.sh
+++ b/build_capi_release.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+set -e
+
+help() {
+    echo "Build a release image with specific changes to enable cluster API provider and upload it to quay.io"
+    echo ""
+    echo "Usage: ./build_capi_release.sh [options] -u <quay.io username>"
+    echo "Options:"
+    echo "-h, --help      show this message"
+    echo "-u, --username  registered username in quay.io"
+    echo "-t, --tag       push to a custom tag in your origin release image repo, default: latest"
+    echo "-r, --release   openshift release version, default: 4.11"
+    echo "-a, --auth      path of registry auth file, default: ./pull-secrets/pull-secret.txt"
+}
+
+: ${TAG:="latest"}
+: ${RELEASE:="4.9"}
+: ${OC_REGISTRY_AUTH_FILE:=$(pwd)"/pull-secrets/pull-secret.txt"}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)
+            help
+            exit 0
+            ;;
+
+        -u|--username)
+            USERNAME=$2
+            shift 2
+            ;;
+
+        -t|--tag)
+            TAG=$2
+            shift 2
+            ;;
+
+        -r|--release)
+            RELEASE=$2
+            shift 2
+            ;;
+
+        -a|--auth)
+            OC_REGISTRY_AUTH_FILE=$2
+            shift 2
+            ;;
+
+        *)
+            echo "Invalid option $1"
+            help
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$USERNAME" ]; then
+    echo "-u/--username was not provided, exiting ..."
+    exit 1
+fi
+
+if [ ! -f "$OC_REGISTRY_AUTH_FILE" ]; then
+    echo "$OC_REGISTRY_AUTH_FILE not found, exiting ..."
+    exit 1
+fi
+
+echo "Building and uploading a custom image for CAPIO"
+./build_operator_image.sh -u "$USERNAME" -o cluster-capi-operator -d Dockerfile.rhel -t "$TAG"
+
+echo "Building a release image"
+./build_release_image.sh -u "$USERNAME" -a "$OC_REGISTRY_AUTH_FILE" \
+    -i cluster-capi-operator=quay.io/"$USERNAME"/cluster-capi-operator:"$TAG"

--- a/build_operator_image.sh
+++ b/build_operator_image.sh
@@ -16,6 +16,7 @@ help() {
     echo "-u, --username    registered username in quay.io"
     echo "-t, --tag         push to a custom tag in your origin release image repo, default: latest"
     echo "-d, --dockerfile  non-default Dockerfile name, default: Dockerfile"
+    echo "--dry-run         if set, build but do not push the image to image registry, default: false"
     echo ""
 }
 
@@ -69,6 +70,11 @@ while [[ $# -gt 0 ]]; do
         -d|--dockerfile)
             DOCKERFILE=$2
             shift 2
+            ;;
+
+        --dry-run)
+            DRY_RUN=true
+            shift
             ;;
 
         *)
@@ -128,12 +134,15 @@ echo "Setting operator image to $OPERATOR_IMAGE"
 echo "Start building operator image"
 podman build --no-cache -t $OPERATOR_IMAGE -f $DOCKERFILE .
 
-echo "Pushing operator image to quay.io"
-podman push $OPERATOR_IMAGE
+if [ -z "$DRY_RUN" ]; then
+  echo "Pushing operator image to quay.io"
+  podman push $OPERATOR_IMAGE
+  echo "Successfully pushed $OPERATOR_IMAGE"
+else
+  echo "Dry run mode is enabled. Do not push $OPERATOR_IMAGE to image registry."
+fi
 
 popd
-
-echo "Successfully pushed $OPERATOR_IMAGE"
 
 echo "Cleaning up"
 rm -rf "build/$OPERATOR_NAME"

--- a/build_operator_image.sh
+++ b/build_operator_image.sh
@@ -8,7 +8,7 @@ help() {
     echo "Usage: ./build_operator_image.sh [options]"
     echo "Options:"
     echo "-h, --help        show this message"
-    echo "-a, --auth        path of OCP CI registry auth file, default: pull-secrets/pull-secrets.json"
+    echo "-a, --auth        path of OCP CI registry auth file, default: ./pull-secrets/pull-secret.txt"
     echo "-o, --operator    operator name to build, examples: machine-config-operator, cluster-kube-controller-manager-operator"
     echo "-i, --id          id of your pull request to apply on top of the master branch"
     echo "-r, --repo-url    repository url for clone"
@@ -21,7 +21,7 @@ help() {
 
 TAG="latest"
 DOCKERFILE="Dockerfile"
-: ${OC_REGISTRY_AUTH_FILE:=$(pwd)"/pull-secrets/pull-secrets.json"}
+: ${OC_REGISTRY_AUTH_FILE:=$(pwd)"/pull-secrets/pull-secret.txt"}
 
 # Parse Options
 while [[ $# -gt 0 ]]; do
@@ -126,8 +126,7 @@ fi
 echo "Setting operator image to $OPERATOR_IMAGE"
 
 echo "Start building operator image"
-# authfile is podman specific option ¯\_(ツ)_/¯. Consider to drop docker for the great good.
-podman build --no-cache -t $OPERATOR_IMAGE -f $DOCKERFILE --authfile="$( realpath "${OC_REGISTRY_AUTH_FILE}")" .
+podman build --no-cache -t $OPERATOR_IMAGE -f $DOCKERFILE .
 
 echo "Pushing operator image to quay.io"
 podman push $OPERATOR_IMAGE

--- a/build_release_image.sh
+++ b/build_release_image.sh
@@ -7,13 +7,14 @@ help() {
     echo ""
     echo "Usage: ./build_release_image.sh [options] -u <quay.io username>"
     echo "Options:"
-    echo "-h, --help     show this message"
-    echo "-u, --username registered username in quay.io"    
-    echo "-t, --tag      push to a custom tag in your origin release image repo, default: latest"
-    echo "-r, --release  openshift release version, default: 4.11"
-    echo "-a, --auth     path of registry auth file, default: ./pull-secrets/pull-secret.txt"
-    echo "-i, --image    image(s) to replace in the release payload in the format '<component_name>=<image_path>'"
-    echo "--dry-run      if set, build but do not push the image to image registry, default: false"
+    echo "-h, --help       show this message"
+    echo "-u, --username   registered username in quay.io"
+    echo "-t, --tag        push to a custom tag in your origin release image repo, default: latest"
+    echo "-r, --release    openshift release version, default: 4.11"
+    echo "-a, --auth       path of registry auth file, default: ./pull-secrets/pull-secret.txt"
+    echo "-i, --image      image(s) to replace in the release payload in the format '<component_name>=<image_path>'"
+    echo "--release-image  custom base release image to build from, default: the latest image for the given release version"
+    echo "--dry-run        if set, build but do not push the image to image registry, default: false"
 }
 
 : ${GOPATH:=${HOME}/go}

--- a/build_release_image.sh
+++ b/build_release_image.sh
@@ -10,14 +10,14 @@ help() {
     echo "-h, --help     show this message"
     echo "-u, --username registered username in quay.io"    
     echo "-t, --tag      push to a custom tag in your origin release image repo, default: latest"
-    echo "-r, --release  openshift release version, default: 4.10"
+    echo "-r, --release  openshift release version, default: 4.11"
     echo "-a, --auth     path of registry auth file, default: ./pull-secrets/pull-secret.txt"
     echo "-i, --image    image(s) to replace in the release payload in the format '<component_name>=<image_path>'"
 }
 
 : ${GOPATH:=${HOME}/go}
 : ${TAG:="latest"}
-: ${RELEASE:="4.10"}
+: ${RELEASE:="4.11"}
 : ${OC_REGISTRY_AUTH_FILE:=$(pwd)"/pull-secrets/pull-secret.txt"}
 
 while [[ $# -gt 0 ]]; do

--- a/build_release_image.sh
+++ b/build_release_image.sh
@@ -11,14 +11,14 @@ help() {
     echo "-u, --username registered username in quay.io"    
     echo "-t, --tag      push to a custom tag in your origin release image repo, default: latest"
     echo "-r, --release  openshift release version, default: 4.10"
-    echo "-a, --auth     path of registry auth file, default: ./pull-secret.txt"
+    echo "-a, --auth     path of registry auth file, default: ./pull-secrets/pull-secret.txt"
     echo "-i, --image    image(s) to replace in the release payload in the format '<component_name>=<image_path>'"
 }
 
 : ${GOPATH:=${HOME}/go}
 : ${TAG:="latest"}
 : ${RELEASE:="4.10"}
-: ${OC_REGISTRY_AUTH_FILE:=$(pwd)"/pull-secrets/pull-secrets.json"}
+: ${OC_REGISTRY_AUTH_FILE:=$(pwd)"/pull-secrets/pull-secret.txt"}
 
 while [[ $# -gt 0 ]]; do
     case "$1" in


### PR DESCRIPTION
This PR includes new features and some bugfixes:
1. Default release version updated to 4.11.
2. Added `dry-run` mode to the scripts that allows not push images in the registry.
3. Added a script to build a release image for cluster-capi-operator.
4. Documentation is updated to include new options.
5. Path to pull-secrets has been fixed.